### PR TITLE
Replace non-existent repos for windows binaries (etc) in CMakeLists.txt and DownloadExternals.cmake - but there's still a build problem on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ if (YUZU_USE_BUNDLED_VCPKG)
         set(VCPKG_DOWNLOADS_PATH ${PROJECT_SOURCE_DIR}/externals/vcpkg/downloads)
         set(NASM_VERSION "2.16.01")
         set(NASM_DESTINATION_PATH ${VCPKG_DOWNLOADS_PATH}/nasm-${NASM_VERSION}-win64.zip)
-        set(NASM_DOWNLOAD_URL "https://github.com/yuzu-emu/ext-windows-bin/raw/master/nasm/nasm-${NASM_VERSION}-win64.zip")
+        set(NASM_DOWNLOAD_URL "https://github.com/yuzu-mirror/ext-windows-bin/raw/master/nasm/nasm-${NASM_VERSION}-win64.zip")
 
         if (NOT EXISTS ${NASM_DESTINATION_PATH})
             file(DOWNLOAD ${NASM_DOWNLOAD_URL} ${NASM_DESTINATION_PATH} SHOW_PROGRESS STATUS NASM_STATUS)
@@ -622,7 +622,7 @@ if (NOT CLANG_FORMAT)
         message(STATUS "Clang format not found! Downloading...")
         set(CLANG_FORMAT "${PROJECT_BINARY_DIR}/externals/clang-format${CLANG_FORMAT_POSTFIX}.exe")
         file(DOWNLOAD
-            https://github.com/yuzu-emu/ext-windows-bin/raw/master/clang-format${CLANG_FORMAT_POSTFIX}.exe
+            https://github.com/yuzu-mirror/ext-windows-bin/raw/master/clang-format${CLANG_FORMAT_POSTFIX}.exe
             "${CLANG_FORMAT}" SHOW_PROGRESS
             STATUS DOWNLOAD_SUCCESS)
         if (NOT DOWNLOAD_SUCCESS EQUAL 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ if (YUZU_USE_BUNDLED_VCPKG)
         set(VCPKG_DOWNLOADS_PATH ${PROJECT_SOURCE_DIR}/externals/vcpkg/downloads)
         set(NASM_VERSION "2.16.01")
         set(NASM_DESTINATION_PATH ${VCPKG_DOWNLOADS_PATH}/nasm-${NASM_VERSION}-win64.zip)
-        set(NASM_DOWNLOAD_URL "https://github.com/yuzu-mirror/ext-windows-bin/raw/master/nasm/nasm-${NASM_VERSION}-win64.zip")
+        set(NASM_DOWNLOAD_URL "https://github.com/litucks/ext-windows-bin/raw/master/nasm/nasm-${NASM_VERSION}-win64.zip")
 
         if (NOT EXISTS ${NASM_DESTINATION_PATH})
             file(DOWNLOAD ${NASM_DOWNLOAD_URL} ${NASM_DESTINATION_PATH} SHOW_PROGRESS STATUS NASM_STATUS)
@@ -622,7 +622,7 @@ if (NOT CLANG_FORMAT)
         message(STATUS "Clang format not found! Downloading...")
         set(CLANG_FORMAT "${PROJECT_BINARY_DIR}/externals/clang-format${CLANG_FORMAT_POSTFIX}.exe")
         file(DOWNLOAD
-            https://github.com/yuzu-mirror/ext-windows-bin/raw/master/clang-format${CLANG_FORMAT_POSTFIX}.exe
+            https://github.com/litucks/ext-windows-bin/raw/master/clang-format${CLANG_FORMAT_POSTFIX}.exe
             "${CLANG_FORMAT}" SHOW_PROGRESS
             STATUS DOWNLOAD_SUCCESS)
         if (NOT DOWNLOAD_SUCCESS EQUAL 0)

--- a/CMakeModules/DownloadExternals.cmake
+++ b/CMakeModules/DownloadExternals.cmake
@@ -7,7 +7,7 @@
 #   prefix_var: name of a variable which will be set with the path to the extracted contents
 function(download_bundled_external remote_path lib_name prefix_var)
 
-set(package_base_url "https://github.com/torzu/")
+set(package_base_url "https://github.com/litucks/")
 set(package_repo "no_platform")
 set(package_extension "no_platform")
 if (WIN32)


### PR DESCRIPTION
NOTE: Aside from the changes suggested, I wasn't sure how to submit the info about the build error now, except via the same pull request.

Fixing the non-existent repo paths _(from "yuzu-emu" and "torzu" to "litucks"... or could use "yuzu-mirror" if there have been no changes to the ext-*****-bin repos)_ corrected some download errors, but CMake configuring still fails with the following:

> -- Looking for include file android/log.h
> -- Looking for include file android/log.h - not found
> -- Looking for include file sys/audioio.h
> -- Looking for include file sys/audioio.h - not found
> -- Looking for include file kai.h
> -- Looking for include file kai.h - not found
> -- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
> CMake Error at C:/Program Files/CMake/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
>   Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
>   system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
>   OPENSSL_INCLUDE_DIR Crypto SSL) (Required is at least version "1.1.1")
> Call Stack (most recent call first):
>   C:/Program Files/CMake/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
>   C:/Program Files/CMake/share/cmake-3.29/Modules/FindOpenSSL.cmake:686 (find_package_handle_standard_args)
>   externals/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
>   externals/cpp-httplib/CMakeLists.txt:118 (find_package)
> 
> 
> -- Configuring incomplete, errors occurred!

Haven't been able to figure out what's causing this yet. (For what it's worth, I'm used to successfully compiling yuzu and sudachi without issues.)

This was my cmake CLI command 
`cmake -E env CXXFLAGS="/Gw" cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_POLICY_DEFAULT_CMP0069=NEW -DYUZU_ENABLE_LTO=ON -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_BUNDLED_SDL2=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DYUZU_TESTS=OFF -DENABLE_QT_TRANSLATION=ON -DENABLE_CUBEB=ON -DENABLE_LIBUSB=ON -DENABLE_WEB_SERVICE=ON -DUSE_DISCORD_PRESENCE=OFF -DYUZU_ROOM=ON -DCMAKE_BUILD_TYPE=Release ..`