### PR TITLE
Remove MSVC compiler version upper limit for QT and SDL to allow compiling with latest version of Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,8 +502,6 @@ if(ENABLE_QT)
         set(YUZU_QT_NO_CMAKE_SYSTEM_PATH)
 
         if(YUZU_USE_BUNDLED_QT)
-            ## removed "AND MSVC_VERSION LESS 1940" below as current Visual Studio version is 19.40.XXX... 
-            ## it would need to be "1941" or higher now. Can leave it out for now until it's necessary again.
             ## if ((MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1940) AND ARCHITECTURE_x86_64)
             if ((MSVC_VERSION GREATER_EQUAL 1920) AND ARCHITECTURE_x86_64)
                 set(QT_BUILD qt-5.15.2-msvc2019_64)
@@ -534,8 +532,6 @@ endif()
 if (ENABLE_SDL2)
     if (YUZU_USE_BUNDLED_SDL2)
         # Detect toolchain and platform
-        ## removed "AND MSVC_VERSION LESS 1940" below as current Visual Studio version is 19.40.XXX... 
-        ## it would need to be "1941" or higher now. Can leave it out for now until it's necessary again.
         ## if ((MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1940) AND ARCHITECTURE_x86_64)
         if ((MSVC_VERSION GREATER_EQUAL 1920) AND ARCHITECTURE_x86_64)
             set(SDL2_VER "SDL2-2.28.2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,7 +502,10 @@ if(ENABLE_QT)
         set(YUZU_QT_NO_CMAKE_SYSTEM_PATH)
 
         if(YUZU_USE_BUNDLED_QT)
-            if ((MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1940) AND ARCHITECTURE_x86_64)
+            ## removed "AND MSVC_VERSION LESS 1940" below as current Visual Studio version is 19.40.XXX... 
+            ## it would need to be "1941" or higher now. Can leave it out for now until it's necessary again.
+            ## if ((MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1940) AND ARCHITECTURE_x86_64)
+            if ((MSVC_VERSION GREATER_EQUAL 1920) AND ARCHITECTURE_x86_64)
                 set(QT_BUILD qt-5.15.2-msvc2019_64)
             elseif ((${CMAKE_SYSTEM_NAME} STREQUAL "Linux") AND NOT MINGW AND ARCHITECTURE_x86_64)
                 set(QT_BUILD qt5_5_15_2)
@@ -531,7 +534,10 @@ endif()
 if (ENABLE_SDL2)
     if (YUZU_USE_BUNDLED_SDL2)
         # Detect toolchain and platform
-        if ((MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1940) AND ARCHITECTURE_x86_64)
+        ## removed "AND MSVC_VERSION LESS 1940" below as current Visual Studio version is 19.40.XXX... 
+        ## it would need to be "1941" or higher now. Can leave it out for now until it's necessary again.
+        ## if ((MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1940) AND ARCHITECTURE_x86_64)
+        if ((MSVC_VERSION GREATER_EQUAL 1920) AND ARCHITECTURE_x86_64)
             set(SDL2_VER "SDL2-2.28.2")
         else()
             message(FATAL_ERROR "No bundled SDL2 binaries for your toolchain. Disable YUZU_USE_BUNDLED_SDL2 and provide your own.")


### PR DESCRIPTION
Commented out the upper limit of "LESS 1940" for the MSVC version for QT and SDL. The current version of the MSVC compiler is 19.40.XXXX, so it needs to be "LESS 1941" or higher to work now.